### PR TITLE
🪲 I-2 added zero address check to `_push()`

### DIFF
--- a/src/Zap.sol
+++ b/src/Zap.sol
@@ -844,6 +844,7 @@ contract Zap is Reentrancy, Errors {
         internal
         returns (bool success)
     {
+        require(_receiver != address(0), PushFailed("Zero Address"));
         IERC20 token = IERC20(_token);
 
         try token.transfer(_receiver, _amount) returns (bool result) {


### PR DESCRIPTION
closes issue #29 

We don't need to add this check to `_pull()` as the funds are being transferred to the zap contract, so there's no chance of losing funds