### PR TITLE
👷 fix: odos unwind swap return

### DIFF
--- a/src/Zap.sol
+++ b/src/Zap.sol
@@ -504,10 +504,10 @@ contract Zap is Reentrancy, Errors, Flush(msg.sender) {
         // i.e., USDC -(repay)-> Aave
         // whatever collateral amount is remaining is returned to the caller
         if (_collateral == USDC) {
-             unwound -= _flashloan;
+            unwound -= _flashloan;
         } else {
             odosSwap(_collateral, _swapAmountIn, _path);
-            unwound -= _swapAmountIn
+            unwound -= _swapAmountIn;
         }
 
         /// @notice the path and max amount in must take into consideration:

--- a/src/Zap.sol
+++ b/src/Zap.sol
@@ -505,7 +505,7 @@ contract Zap is Reentrancy, Errors, Flush(msg.sender) {
         // whatever collateral amount is remaining is returned to the caller
         unwound -= _collateral == USDC
             ? _flashloan
-            : odosSwap(_collateral, _swapAmountIn, _path);
+            : odosSwapForUnwind(_collateral, _swapAmountIn, _path);
 
         /// @notice the path and max amount in must take into consideration:
         ///     (1) Aave flashloan amount
@@ -670,6 +670,23 @@ contract Zap is Reentrancy, Errors, Flush(msg.sender) {
         amountOut = abi.decode(result, (uint256));
 
         IERC20(_tokenFrom).approve(ROUTER, 0);
+    }
+
+    /// @dev wrapper around odosSwap that returns input amount instead of output
+    /// amount
+    /// @param _tokenFrom address of token being swapped
+    /// @param _amountIn amount of token being swapped
+    /// @param _swapPath bytes from odos assemble api containing the swap
+    function odosSwapForUnwind(
+        address _tokenFrom,
+        uint256 _amountIn,
+        bytes memory _swapPath
+    )
+        internal
+        returns (uint256)
+    {
+        odosSwap(_tokenFrom, _amountIn, _swapPath);
+        return _amountIn;
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix for `odosSwap` return value design when called during unwind process.